### PR TITLE
GitHub Actions CI (Only Update Cache on Master Push)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,103 +5,11 @@ on: [push, pull_request]
 env:
   CACHE_IMAGE: fmrcampos/docker-ci-cache
   GPR_CACHE_IMAGE: docker.pkg.github.com/${{ github.repository }}/docker-ci-cache
-  DOCKER_BUILDKIT: 1
   CACHE_SEED: 1
   NODE_VERSION: 14.4.0
 
 jobs:
-  build-dh:
-    name: Docker Hub Cache
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v1
-      - name: Log in to docker hub
-        run: echo ${{ secrets.REGISTRY_PASS }} | docker login -u ${{ secrets.REGISTRY_USER }} --password-stdin
-      - name: Build static from dockerfile
-        run: |
-          docker build \
-            --target static \
-            --cache-from $CACHE_IMAGE:static \
-            --tag $CACHE_IMAGE:static \
-            --file ./Dockerfile \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            "."
-      - name: Build build from dockerfile
-        run: |
-          docker build \
-            --target build \
-            --cache-from $CACHE_IMAGE:static \
-            --cache-from $CACHE_IMAGE:build \
-            --tag $CACHE_IMAGE:build \
-            --file ./Dockerfile \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            "."
-      - name: Build stage from dockerfile
-        run: |
-          docker build \
-            --cache-from $CACHE_IMAGE:build \
-            --cache-from $CACHE_IMAGE:stage \
-            --tag $CACHE_IMAGE:stage \
-            --file ./Dockerfile \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            "."
-      - name: Push static image to Docker Hub
-        run: docker push $CACHE_IMAGE:static
-      - name: Push build image to Docker Hub
-        run: docker push $CACHE_IMAGE:build
-      - name: Push stage image to Docker Hub
-        run: docker push $CACHE_IMAGE:stage
-
-  build-gpr:
-    if: false # https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358
-    name: GitHub Package Registry Cache
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v1
-      - name: Log in to GitHub Package Registry
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-      - name: Build static image from Dockerfile
-        run: |
-          docker pull $GPR_CACHE_IMAGE:static || true
-          docker build \
-            --target static \
-            --cache-from $GPR_CACHE_IMAGE:static \
-            --tag $GPR_CACHE_IMAGE:static \
-            --file ./Dockerfile \
-            # can't use BuildKit for GPR
-            "."
-      - name: Build build image from Dockerfile
-        run: |
-          docker pull $GPR_CACHE_IMAGE:build || true
-          docker build \
-            --target build \
-            --cache-from $GPR_CACHE_IMAGE:static \
-            --cache-from $GPR_CACHE_IMAGE:build \
-            --tag $GPR_CACHE_IMAGE:build \
-            --file ./Dockerfile \
-            # can't use BuildKit for GPR
-            "."
-      - name: Build stage image from Dockerfile
-        run: |
-          docker pull $GPR_CACHE_IMAGE:stage || true
-          docker build \
-            --cache-from $GPR_CACHE_IMAGE:build \
-            --cache-from $GPR_CACHE_IMAGE:stage \
-            --tag $GPR_CACHE_IMAGE:stage \
-            --file ./Dockerfile \
-            # can't use BuildKit for GPR
-            "."
-      - name: Push static image to package registry
-        run: docker push $GPR_CACHE_IMAGE:static
-      - name: Push build image to package registry
-        run: docker push $GPR_CACHE_IMAGE:build
-      - name: Push stage image to package registry
-        run: docker push $GPR_CACHE_IMAGE:stage
-  
   test:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     services:
@@ -202,7 +110,6 @@ jobs:
           POSTGRES_PORT: 5432
 
   lint:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     steps:
@@ -219,7 +126,6 @@ jobs:
           make lint ACTIONS=true
 
   docs:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     steps:
@@ -232,7 +138,6 @@ jobs:
           make docs
   
   deps:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     steps:
@@ -266,7 +171,6 @@ jobs:
         run: make deps
 
   licenses:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     steps:
@@ -277,7 +181,6 @@ jobs:
         run: bin/licenses
   
   translations:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:stage
     steps:
@@ -290,7 +193,6 @@ jobs:
           make translations
 
   static-lint:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:static
     steps:
@@ -304,7 +206,6 @@ jobs:
           ./node_modules/.bin/sass-lint --verbose
 
   static-tests:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:static
     steps:
@@ -340,7 +241,6 @@ jobs:
         run: bin/static_tests
 
   static-pipeline:
-    needs: build-dh
     runs-on: ubuntu-latest
     container: fmrcampos/docker-ci-cache:static
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ env:
   CACHE_IMAGE: fmrcampos/docker-ci-cache
   GPR_CACHE_IMAGE: docker.pkg.github.com/${{ github.repository }}/docker-ci-cache
   CACHE_SEED: 1
+  DOCKER_BUILDKIT: 1
   NODE_VERSION: 14.4.0
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     services:
       postgres:
         image: postgres:10.1
@@ -20,9 +20,23 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: Cache pip dependencies
         uses: actions/cache@v2
@@ -68,16 +82,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies
-        run: |
-          apt-get update && apt-get -y install make locales build-essential curl libpq-dev autoconf
-          apt -y install libcurl4-openssl-dev libssl-dev pkg-config
-
-      - name: Set locale
-        run: |
-          echo "LC_ALL=en_US.UTF-8" >> /etc/environment
-          echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-          echo "LANG=en_US.UTF-8" > /etc/locale.conf
-          locale-gen en_US.UTF-8
+        run: sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config
 
       - name: Install pip requirements
         run: |
@@ -100,21 +105,27 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m coverage run -m pytest --strict --postgresql-host postgres
+          python -m coverage run -m pytest --strict --postgresql-host localhost
           python -m coverage html
           python -m coverage report -m --fail-under 100
         env:
           # The hostname used to communicate with the PostgreSQL service container
-          POSTGRES_HOST: postgres
+          POSTGRES_HOST: localhost
           # The default PostgreSQL port
           POSTGRES_PORT: 5432
 
   lint:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
 
       - uses: actions/setup-python@v2
         with:
@@ -122,27 +133,47 @@ jobs:
 
       - name: Lint
         run: |
-          apt-get update && apt-get install make
+          sudo apt-get update && sudo apt-get install make
           make lint ACTIONS=true
 
   docs:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
       - name: Documentation
         run: |
-          apt-get update && apt-get install make
+          sudo apt-get update && sudo apt-get install make
           make docs
   
   deps:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: Cache pip dependencies
         uses: actions/cache@v2
@@ -159,8 +190,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update && apt-get -y install build-essential make libpq-dev
-          apt -y install libcurl4-openssl-dev libssl-dev pkg-config
+          sudo apt -y install libcurl4-openssl-dev libssl-dev pkg-config
           mkdir ./.cache && mkdir ./.cache/pip
           chown -R $(whoami) ./.cache/pip
           pip install -U pip setuptools wheel --cache-dir ./.cache/pip
@@ -172,32 +202,52 @@ jobs:
 
   licenses:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
 
       - name: Check licenses
         run: bin/licenses
   
   translations:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:stage
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: stage
+          build_extra_args: "--cache-from ${{ env.CACHE_IMAGE }}:static --cache-from ${{ env.CACHE_IMAGE }}:build --cache-from ${{ env.CACHE_IMAGE }}:stage --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
       - name: Check translations
-        run: |
-          apt-get update && apt-get -y install make
-          make translations
+        run: make translations
 
   static-lint:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:static
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: static
+          build_extra_args: "--target static --cache-from ${{ env.CACHE_IMAGE }}:static --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
 
       - name: Static Lint Check
         run: |
@@ -207,10 +257,16 @@ jobs:
 
   static-tests:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:static
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: static
+          build_extra_args: "--target static --cache-from ${{ env.CACHE_IMAGE }}:static --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -228,24 +284,24 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Locale & Dependency Setup
-        run: |
-          apt-get update && apt-get -y install locales
-          echo "LC_ALL=en_US.UTF-8" >> /etc/environment
-          echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-          echo "LANG=en_US.UTF-8" > /etc/locale.conf
-          locale-gen en_US.UTF-8
-          npm install -D babel
+      - name: Dependency Setup
+        run: npm install -D babel
 
       - name: Static Tests
         run: bin/static_tests
 
   static-pipeline:
     runs-on: ubuntu-latest
-    container: fmrcampos/docker-ci-cache:static
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - uses: whoan/docker-build-with-cache-action@master
+        with:
+          image_name: ${{ env.CACHE_IMAGE }}
+          image_tag: static
+          build_extra_args: "--target static --cache-from ${{ env.CACHE_IMAGE }}:static --build-arg BUILDKIT_INLINE_CACHE=1"
+          push_image_and_stages: false
 
       - name: Cache node version manager
         uses: actions/cache@v2
@@ -277,14 +333,8 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Locale & Dependency Setup
-        run: |
-          apt-get update && apt-get -y install locales
-          echo "LC_ALL=en_US.UTF-8" >> /etc/environment
-          echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-          echo "LANG=en_US.UTF-8" > /etc/locale.conf
-          locale-gen en_US.UTF-8
-          npm install -D babel
+      - name: Dependency Setup
+        run: npm install -D babel
 
       - name: Static Pipeline Check
         run: bin/static_pipeline

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,102 @@
+name: Registry Image Caching
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  CACHE_IMAGE: fmrcampos/docker-ci-cache
+  GPR_CACHE_IMAGE: docker.pkg.github.com/${{ github.repository }}/docker-ci-cache
+  DOCKER_BUILDKIT: 1
+
+update-cache:
+  build-dh:
+    name: Docker Hub Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v1
+      - name: Log in to docker hub
+        run: echo ${{ secrets.REGISTRY_PASS }} | docker login -u ${{ secrets.REGISTRY_USER }} --password-stdin
+      - name: Build static from dockerfile
+        run: |
+          docker build \
+            --target static \
+            --cache-from $CACHE_IMAGE:static \
+            --tag $CACHE_IMAGE:static \
+            --file ./Dockerfile \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            "."
+      - name: Build build from dockerfile
+        run: |
+          docker build \
+            --target build \
+            --cache-from $CACHE_IMAGE:static \
+            --cache-from $CACHE_IMAGE:build \
+            --tag $CACHE_IMAGE:build \
+            --file ./Dockerfile \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            "."
+      - name: Build stage from dockerfile
+        run: |
+          docker build \
+            --cache-from $CACHE_IMAGE:build \
+            --cache-from $CACHE_IMAGE:stage \
+            --tag $CACHE_IMAGE:stage \
+            --file ./Dockerfile \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            "."
+      - name: Push static image to Docker Hub
+        run: docker push $CACHE_IMAGE:static
+      - name: Push build image to Docker Hub
+        run: docker push $CACHE_IMAGE:build
+      - name: Push stage image to Docker Hub
+        run: docker push $CACHE_IMAGE:stage
+
+  build-gpr:
+    if: false # https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358
+    name: GitHub Package Registry Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v1
+      - name: Log in to GitHub Package Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - name: Build static image from Dockerfile
+        run: |
+          docker pull $GPR_CACHE_IMAGE:static || true
+          docker build \
+            --target static \
+            --cache-from $GPR_CACHE_IMAGE:static \
+            --tag $GPR_CACHE_IMAGE:static \
+            --file ./Dockerfile \
+            # can't use BuildKit for GPR
+            "."
+      - name: Build build image from Dockerfile
+        run: |
+          docker pull $GPR_CACHE_IMAGE:build || true
+          docker build \
+            --target build \
+            --cache-from $GPR_CACHE_IMAGE:static \
+            --cache-from $GPR_CACHE_IMAGE:build \
+            --tag $GPR_CACHE_IMAGE:build \
+            --file ./Dockerfile \
+            # can't use BuildKit for GPR
+            "."
+      - name: Build stage image from Dockerfile
+        run: |
+          docker pull $GPR_CACHE_IMAGE:stage || true
+          docker build \
+            --cache-from $GPR_CACHE_IMAGE:build \
+            --cache-from $GPR_CACHE_IMAGE:stage \
+            --tag $GPR_CACHE_IMAGE:stage \
+            --file ./Dockerfile \
+            # can't use BuildKit for GPR
+            "."
+      - name: Push static image to package registry
+        run: docker push $GPR_CACHE_IMAGE:static
+      - name: Push build image to package registry
+        run: docker push $GPR_CACHE_IMAGE:build
+      - name: Push stage image to package registry
+        run: docker push $GPR_CACHE_IMAGE:stage

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -10,7 +10,7 @@ env:
   GPR_CACHE_IMAGE: docker.pkg.github.com/${{ github.repository }}/docker-ci-cache
   DOCKER_BUILDKIT: 1
 
-update-cache:
+jobs:
   build-dh:
     name: Docker Hub Cache
     runs-on: ubuntu-latest


### PR DESCRIPTION
[registry.yml](https://github.com/callmecampos/warehouse/blob/github-actions-ci-master-cache/.github/workflows/registry.yml): only runs on pushes to the master branch, rebuilds each stage of the multi-stage Dockerfile and pushes to Docker Hub

[main.yml](https://github.com/callmecampos/warehouse/blob/github-actions-ci-master-cache/.github/workflows/main.yml): uses the [Docker build-with-cache action](https://github.com/marketplace/actions/build-docker-images-using-cache) to build the relevant container stage for each job